### PR TITLE
fix: use 'hx' to start the Helix editor

### DIFF
--- a/docs/nixos-with-flakes/nixos-with-flakes-enabled.md
+++ b/docs/nixos-with-flakes/nixos-with-flakes-enabled.md
@@ -197,7 +197,7 @@ Then update `configuration.nix` to install `helix` from the input `helix`:
 }
 ```
 
-To deploy the changes, run `sudo nixos-rebuild switch`. Then start the Helix editor by running the `helix` command.
+To deploy the changes, run `sudo nixos-rebuild switch`. Then start the Helix editor by running the `hx` command.
 
 ## Add Custom Cache Mirror
 

--- a/docs/zh/nixos-with-flakes/nixos-with-flakes-enabled.md
+++ b/docs/zh/nixos-with-flakes/nixos-with-flakes-enabled.md
@@ -192,7 +192,7 @@ cat flake.nix
 }
 ```
 
-改好后再 `sudo nixos-rebuild switch` 部署，就能安装好 helix 程序了，可直接在终端使用 `helix` 命令测试验证。
+改好后再 `sudo nixos-rebuild switch` 部署，就能安装好 helix 程序了，可直接在终端使用 `hx` 命令测试验证。
 
 ## 为 Flake 添加国内 cache 源 {#add-cache-source-for-flake}
 


### PR DESCRIPTION
Very minor fix here: `hx` starts Helix rather than `helix` on NixOS https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/applications/editors/helix/default.nix#L49 and via the flake

(Some distros do rename the binary to `helix` like [the Arch package](https://archlinux.org/packages/extra/x86_64/helix/) because of a conflict with another `hx` binary.)

Thanks!