### PR TITLE
Fix syxtax error in Modularize the Configuration

### DIFF
--- a/docs/nixos-with-flakes/modularize-the-configuration.md
+++ b/docs/nixos-with-flakes/modularize-the-configuration.md
@@ -35,7 +35,7 @@ With the help of `imports`, we can split `home.nix` and `configuration.nix` into
   ...
 }: {
   imports = [
-    (import ./special-fonts-1.nix {inherit config pkgs}) # (1)
+    (import ./special-fonts-1.nix {inherit config pkgs;}) # (1)
     ./special-fonts-2.nix # (2)
   ];
 


### PR DESCRIPTION
I'm new to Nix, but I'm _pretty_ sure there needs to be a semicolon after each key-value declaration in an attribute set, even when using `inherit`.

The same error doesn't seem to appear in the Chinese translation for this page (the two versions seem to have diverged a bit).