### PR TITLE
fix: chromium rebuild

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701742334,
-        "narHash": "sha256-kofCitkjb+AjyMqV9xFFTfr36ZV+yohZDWrRVvos3tk=",
+        "lastModified": 1701802827,
+        "narHash": "sha256-wTn0lpV75Uv6tU6haEypNsmnJJPb0hpaMIy/4uf5AiQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1f39de03a7b65f29bbb71e0630af11f8e6a64377",
+        "rev": "a804fc878d7ba1558b960b4c64b0903da426ac41",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A Nix-flake-based Node.js development environment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -22,6 +22,7 @@
         })
       ];
       pkgs = import nixpkgs { inherit overlays system; };
+      pkgs_chromium = import nixpkgs { inherit system; };
     in
     {
       devShells.default = pkgs.mkShell {
@@ -33,7 +34,7 @@
           # Set Puppeteer to not download Chrome, cause it doesn't work on NixOS
           export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
           # Set Puppeteer to use Chromium from Nixpkgs
-          export PUPPETEER_EXECUTABLE_PATH=${pkgs.chromium.outPath}/bin/chromium
+          export PUPPETEER_EXECUTABLE_PATH=${pkgs_chromium.chromium.outPath}/bin/chromium
         '';
       };
     });


### PR DESCRIPTION
I wanted to contribute to this repo and stumbled upon that Nix rebuilds chromium (because of `nixpkgs/release-23.11` and overlay), when you invoke `nix develop`.

This PR effectively prevents building chromium from source and instead will pull binary from cache.