### PR TITLE
fix: "Home Manager Manual" refrence changed from `.html` to `.xhtml`

### DIFF
--- a/docs/nixos-with-flakes/start-using-home-manager.md
+++ b/docs/nixos-with-flakes/start-using-home-manager.md
@@ -2,7 +2,7 @@
 
 As I mentioned earlier, NixOS can only manage system-level configuration. To manage user-level configuration in the Home directory, we need to install Home Manager.
 
-According to the official [Home Manager Manual](https://nix-community.github.io/home-manager/index.html), to install Home Manager as a module of NixOS, we first need to create `/etc/nixos/home.nix`. Here's an example of its contents:
+According to the official [Home Manager Manual](https://nix-community.github.io/home-manager/index.xhtml), to install Home Manager as a module of NixOS, we first need to create `/etc/nixos/home.nix`. Here's an example of its contents:
 
 ```nix
 { config, pkgs, ... }:


### PR DESCRIPTION
- Changed the "Home Manager Manual"  url link on the "Getting Started with Home Manager" section from `*.html` to `*.xhtml`