### PR TITLE
Fixes typo: substituers -> substituters

### DIFF
--- a/docs/zh/nixos-with-flakes/add-custom-cache-servers.md
+++ b/docs/zh/nixos-with-flakes/add-custom-cache-servers.md
@@ -19,30 +19,30 @@ Nix 提供了官方缓存服务器 <https://cache.nixos.org>，它缓存了 nixp
 
 Nix 中通过如下几个 options 来配置缓存服务器：
 
-1. [substituers](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-substituters): 它是一个字符串数组，每个字符串都是一个缓存服务器的地址，Nix 会按照数组中的顺序依次尝试从这些服务器中查找缓存。
-2. [trusted-public-keys](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-trusted-public-keys): 为了防范恶意攻击，Nix 默认启用 [require-sigs](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-require-sigs) 功能，只有附带了签名、且签名能被 `trusted-public-keys` 中的任意一个公钥验证通过的缓存，才会被 Nix 使用。因此我们需要将 `substituers` 对应的公钥添加到 `trusted-public-keys` 中。
+1. [substituters](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-substituters): 它是一个字符串数组，每个字符串都是一个缓存服务器的地址，Nix 会按照数组中的顺序依次尝试从这些服务器中查找缓存。
+2. [trusted-public-keys](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-trusted-public-keys): 为了防范恶意攻击，Nix 默认启用 [require-sigs](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-require-sigs) 功能，只有附带了签名、且签名能被 `trusted-public-keys` 中的任意一个公钥验证通过的缓存，才会被 Nix 使用。因此我们需要将 `substituters` 对应的公钥添加到 `trusted-public-keys` 中。
    1. 国内的镜像源都是直接从官方缓存服务器中同步的，因此它们的公钥与官方缓存服务器的公钥是一致的，我们可以直接使用官方缓存服务器的公钥，无需额外配置。
    2. 这种完全依赖公钥机制的验证方式，实际是将安全责任转嫁给了用户。用户如果希望使用某个第三方库，但又希望使用它的第三方缓存服务器加快构建速度，那就必须自己承担对应的安全风险，自行决策是否将该缓存服务器的公钥添加进 `trusted-public-keys`。为了完全解决这个信任问题，Nix 推出了实验特性 [ca-derivations](https://nixos.wiki/wiki/Ca-derivations)，它不依赖 `trusted-public-keys` 进行签名校验，有兴趣的可以自行了解。
 
-可通过如下几种方式来配置 `substituers` `trusted-public-keys` 两个参数：
+可通过如下几种方式来配置 `substituters` `trusted-public-keys` 两个参数：
 
 1. 在 `/etc/nix/nix.conf` 中配置，这是全局配置，对所有用户生效。
-   1. 可在任一 NixOS Module 中通过 `nix.settings.substituers` 与 `nix.settings.trusted-public-keys` 来声明式地生成 `/etc/nix/nix.conf`.
-2. 在 flake 项目的 `flake.nix` 中通过 `nixConfig.substituers` 来配置，此配置仅对当前 flake 生效。
-3. 可通过 `nix` 指令的 `--option substituers="http://xxx"` 参数来临时设定，此配置仅对当前指令生效。
+   1. 可在任一 NixOS Module 中通过 `nix.settings.substituters` 与 `nix.settings.trusted-public-keys` 来声明式地生成 `/etc/nix/nix.conf`.
+2. 在 flake 项目的 `flake.nix` 中通过 `nixConfig.substituters` 来配置，此配置仅对当前 flake 生效。
+3. 可通过 `nix` 指令的 `--option substituters="http://xxx"` 参数来临时设定，此配置仅对当前指令生效。
 
 上面三种方式中，除了第一种全局配置外，其他两种都是临时配置。如果同时使用了多种方式，那么后面的配置会直接覆盖前面的配置。
 
-但临时设置 `substituers` 存在安全风险，前面我们也解释了基于 `trusted-public-keys` 的安全验证机制存在缺陷。
-将一个不可信的缓存服务器添加到 substituers 中，可能会导致包含恶意内容的缓存被复制到 Nix Store 中。
-因此 Nix 对 substituers 的临时设置做出了限制，要想通过第二三种方式设定 substituers，前提是满足如下任意一个条件：
+但临时设置 `substituters` 存在安全风险，前面我们也解释了基于 `trusted-public-keys` 的安全验证机制存在缺陷。
+将一个不可信的缓存服务器添加到 substituters 中，可能会导致包含恶意内容的缓存被复制到 Nix Store 中。
+因此 Nix 对 substituters 的临时设置做出了限制，要想通过第二三种方式设定 substituers，前提是满足如下任意一个条件：
 
 1. [`/etc/nix/nix.conf` 中的 `trusted-users`](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-trusted-users) 参数列表中包含当前用户。
-2. [`/etc/nix/nix.conf` 中的 `trusted-substituters`](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-trusted-substituters) 参数列表中包含我们临时指定的 substituers.
+2. [`/etc/nix/nix.conf` 中的 `trusted-substituters`](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-trusted-substituters) 参数列表中包含我们临时指定的 substituters.
 
 基于上述信息，如下是上述三种配置方式的示例。
 
-首先是通过 `nix.settings` 声明式地配置系统层面的 substituers 与 trusted-public-keys, 将如下配置添加到 `/etc/nixos/configuration.nix` 或其他任一 NixOS Module 中即可：
+首先是通过 `nix.settings` 声明式地配置系统层面的 substituters 与 trusted-public-keys, 将如下配置添加到 `/etc/nixos/configuration.nix` 或其他任一 NixOS Module 中即可：
 
 ```nix{7-27}
 {
@@ -53,8 +53,8 @@ Nix 中通过如下几个 options 来配置缓存服务器：
   # ...
   nix.settings = {
     # given the users in this list the right to specify additional substituters via:
-    #    1. `nixConfig.substituers` in `flake.nix`
-    #    2. command line args `--options substituers http://xxx`
+    #    1. `nixConfig.substituters` in `flake.nix`
+    #    2. command line args `--options substituters http://xxx`
     trusted-users = ["ryan"];
 
     substituters = [
@@ -76,7 +76,7 @@ Nix 中通过如下几个 options 来配置缓存服务器：
 }
 ```
 
-第二种方案是通过 `flake.nix` 配置 substituers 与 trusted-public-keys，将如下配置添加到 `flake.nix` 中即可：
+第二种方案是通过 `flake.nix` 配置 substituters 与 trusted-public-keys，将如下配置添加到 `flake.nix` 中即可：
 
 > 如前所述，此配置中的 `nix.settings.trusted-users` 也是必须配置的，否则我们在这里设置的 `substituters` 将无法生效。
 
@@ -125,7 +125,7 @@ Nix 中通过如下几个 options 来配置缓存服务器：
 
           {
             # given the users in this list the right to specify additional substituters via:
-            #    1. `nixConfig.substituers` in `flake.nix`
+            #    1. `nixConfig.substituters` in `flake.nix`
             nix.settings.trusted-users = [ "ryan" ];
           }
           # 省略若干配置...
@@ -136,10 +136,10 @@ Nix 中通过如下几个 options 来配置缓存服务器：
 }
 ```
 
-以及第三种方案，使用如下命令在部署时临时指定 substituers 与 trusted-public-keys:
+以及第三种方案，使用如下命令在部署时临时指定 substituters 与 trusted-public-keys:
 
 ```bash
-sudo nixos-rebuild switch --option substituers "https://nix-community.cachix.org" --option trusted-public-keys "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+sudo nixos-rebuild switch --option substituters "https://nix-community.cachix.org" --option trusted-public-keys "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
 ```
 
 选择上述三种方案的任一一种进行配置并部署，部署成功之后，后续所有的包都会优先从国内镜像源查找缓存。
@@ -148,11 +148,11 @@ sudo nixos-rebuild switch --option substituers "https://nix-community.cachix.org
 
 ### Nix options 参数的 `extra-` 前缀
 
-前面提到的三种方式配置的 `substituers` 会相互覆盖，但比较理想的情况应该是：
+前面提到的三种方式配置的 `substituters` 会相互覆盖，但比较理想的情况应该是：
 
-1. 在系统层面的 `/etc/nix/nix.conf` 中仅配置最通用的 substituers 与 trusted-public-keys，例如官方缓存服务器与国内镜像源。
-2. 在每个 flake 项目的 `flake.nix` 中配置该项目特有的 substituers 与 trusted-public-keys，例如 nix-community 等非官方的缓存服务器。
-3. 在构建 flake 项目时，应该将 `flake.nix` 与 `/etx/nix/nix.conf` 中配置的 substituers 与 trusted-public-keys **合并**使用。
+1. 在系统层面的 `/etc/nix/nix.conf` 中仅配置最通用的 substituters 与 trusted-public-keys，例如官方缓存服务器与国内镜像源。
+2. 在每个 flake 项目的 `flake.nix` 中配置该项目特有的 substituters 与 trusted-public-keys，例如 nix-community 等非官方的缓存服务器。
+3. 在构建 flake 项目时，应该将 `flake.nix` 与 `/etx/nix/nix.conf` 中配置的 substituters 与 trusted-public-keys **合并**使用。
 
 Nix 提供了 [`extra-` 前缀](https://nixos.org/manual/nix/stable/command-ref/conf-file.html?highlight=extra#file-format) 实现了这个**合并**功能。
 
@@ -199,10 +199,10 @@ Nix 提供了 [`extra-` 前缀](https://nixos.org/manual/nix/stable/command-ref/
 
           {
             # given the users in this list the right to specify additional substituters via:
-            #    1. `nixConfig.substituers` in `flake.nix`
+            #    1. `nixConfig.substituters` in `flake.nix`
             nix.settings.trusted-users = [ "ryan" ];
 
-            # the system-level substituers & trusted-public-keys
+            # the system-level substituters & trusted-public-keys
             nix.settings = {
               substituters = [
                 # cache mirror located in China


### PR DESCRIPTION
Fixes 44 misspellings of the word `substituters` across two files:
- docs/nixos-with-flakes/add-custom-cache-servers.md
- docs/zh/nixos-with-flakes/add-custom-cache-servers.md