### PR TITLE
add: a way to input your flake through a tar.gz link

### DIFF
--- a/docs/other-usage-of-flakes/inputs.md
+++ b/docs/other-usage-of-flakes/inputs.md
@@ -10,6 +10,9 @@ The `inputs` section in `flake.nix` is an attribute set used to specify the depe
     nixpkgs.url = "github:Mic92/nixpkgs/master";
     # Git URL, applicable to any Git repository using the https/ssh protocol.
     git-example.url = "git+https://git.somehost.tld/user/path?ref=branch";
+    # Archive File URL, needed in case your input use LFS.
+    # Regular git input doesn't support LFS yet.
+    git-example.url = "https://codeberg.org/solver-orgz/treedome/archive/master.tar.gz";
     # Similar to fetching a Git repository, but using the ssh protocol 
     # with key authentication. Also uses the shallow=1 parameter 
     # to avoid copying the .git directory.


### PR DESCRIPTION
The regular git flake input doesn't support LFS yet, so a tar.gz link is needed here.