### PR TITLE
link to new nixos wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ who already contributed to this project!
 [NixOS & Flakes Book](https://github.com/ryan4yin/nixos-and-flakes-book) © 2023 by Ryan
 Yin is licensed under [CC BY-SA 4.0](./LICENSE.md)
 
-[^1]: [Flakes - NixOS Wiki](https://nixos.wiki/index.php?title=Flakes)
+[^1]: [Flakes - NixOS Wiki](https://wiki.nixos.org/wiki/Flakes)
 [^2]:
     [Flakes are such an obviously good thing](https://grahamc.com/blog/flakes-are-an-obviously-good-thing/)
 

--- a/docs/development/distributed-building.md
+++ b/docs/development/distributed-building.md
@@ -151,7 +151,7 @@ Here are some observed issues and limitations:
 
 ## References
 
-- [Distributed build - NixOS Wiki](https://nixos.wiki/wiki/Distributed_build)
+- [Distributed build - NixOS Wiki](https://wiki.nixos.org/wiki/Distributed_build)
 - [Document available system features - nix#7380](https://github.com/NixOS/nix/issues/7380)
 - [Distributed builds seem to disable local builds - nix#2589](https://github.com/NixOS/nix/issues/2589)
 - [Offloading NixOS builds to a faster machine](https://sgt.hootr.club/molten-matter/nix-distributed-builds/)

--- a/docs/development/intro.md
+++ b/docs/development/intro.md
@@ -483,8 +483,8 @@ documentation.
 
 - [pkgs.mkShell - nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell)
 - [A minimal nix-shell](https://fzakaria.com/2021/08/02/a-minimal-nix-shell.html)
-- [Wrapping packages - NixOS Cookbook](https://nixos.wiki/wiki/Nix_Cookbook#Wrapping_packages)
+- [Wrapping packages - NixOS Cookbook](https://wiki.nixos.org/wiki/Nix_Cookbook#Wrapping_packages)
 - [One too many shell, Clearing up with nix' shells nix shell and nix-shell - Yannik Sander](https://blog.ysndr.de/posts/guides/2021-12-01-nix-shells/)
-- [Shell Scripts - NixOS Wiki](https://nixos.wiki/wiki/Shell_Scripts)
+- [Shell Scripts - NixOS Wiki](https://wiki.nixos.org/wiki/Shell_Scripts)
 
 [New Nix Commands]: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix.html

--- a/docs/development/kernel-development.md
+++ b/docs/development/kernel-development.md
@@ -80,7 +80,7 @@ An example of kernel development with `flake.nix`.
       };
     in
       # the code here is mainly copied from:
-      #   https://nixos.wiki/wiki/Linux_kernel#Embedded_Linux_Cross-compile_xconfig_and_menuconfig
+      #   https://wiki.nixos.org/wiki/Linux_kernel#Embedded_Linux_Cross-compile_xconfig_and_menuconfig
       (pkgs.buildFHSUserEnv {
         name = "kernel-build-env";
         targetPkgs = pkgs_: (with pkgs_;
@@ -116,5 +116,5 @@ and use `make menuconfig` to configure the kernel.
 
 ## References
 
-- [Linux kernel - NixOS Wiki](https://nixos.wiki/wiki/Linux_kernel)
+- [Linux kernel - NixOS Wiki](https://wiki.nixos.org/wiki/Linux_kernel)
 - https://github.com/jordanisaacs/kernel-module-flake

--- a/docs/development/packaging-101.md
+++ b/docs/development/packaging-101.md
@@ -9,7 +9,7 @@ packaging.
 - [How to Learn Nix, Part 28: The standard environment](https://ianthehenry.com/posts/how-to-learn-nix/the-standard-environment/)
 - [stdenv - Nixpkgs Manual](https://github.com/NixOS/nixpkgs/tree/nixos-unstable/doc/stdenv)
 - [languages-frameworks - Nixpkgs Manual](https://github.com/NixOS/nixpkgs/tree/nixos-unstable/doc/languages-frameworks)
-- [Wrapping packages - NixOS Cookbook](https://nixos.wiki/wiki/Nix_Cookbook#Wrapping_packages)
+- [Wrapping packages - NixOS Cookbook](https://wiki.nixos.org/wiki/Nix_Cookbook#Wrapping_packages)
 - Useful tools:
   - [nurl](https://github.com/nix-community/nurl): Generate Nix fetcher calls from
     repository URLs

--- a/docs/nix-store/add-binary-cache-servers.md
+++ b/docs/nix-store/add-binary-cache-servers.md
@@ -37,7 +37,7 @@ In Nix, you can configure cache servers using the following options:
       the build process of a certain library, they must take on the corresponding security
       risks and decide whether to add the public key of that cache server to
       `trusted-public-keys`. To completely solve this trust issue, Nix has introduced the
-      experimental feature [ca-derivations](https://nixos.wiki/wiki/Ca-derivations), which
+      experimental feature [ca-derivations](https://wiki.nixos.org/wiki/Ca-derivations), which
       does not depend on `trusted-public-keys` for signature verification. Interested
       users can explore it further.
 

--- a/docs/nix-store/host-your-own-binary-cache-server.md
+++ b/docs/nix-store/host-your-own-binary-cache-server.md
@@ -223,6 +223,6 @@ are not stored indefinitely.
 ### References {#references}
 
 - [Blog post by Jeff on Nix binary caches](https://jcollie.github.io/nixos/2022/04/27/nixos-binary-cache-2022.html)
-- [Binary cache in the NixOS wiki](https://nixos.wiki/wiki/Binary_Cache)
+- [Binary cache in the NixOS wiki](https://wiki.nixos.org/wiki/Binary_Cache)
 - [Serving a Nox store via S3 in the NixOS manual](https://nixos.org/manual/nix/stable/package-management/s3-substituter.html)
 - [Serving a Nix store via HTTP in the NixOS manual](https://nixos.org/manual/nix/stable/package-management/binary-cache-substituter.html)

--- a/docs/nixos-with-flakes/get-started-with-nixos.md
+++ b/docs/nixos-with-flakes/get-started-with-nixos.md
@@ -106,4 +106,4 @@ To find configuration options and documentation:
 
 ## References
 
-- [Overview of the NixOS Linux distribution](https://nixos.wiki/wiki/Overview_of_the_NixOS_Linux_distribution)
+- [Overview of the NixOS Linux distribution](https://wiki.nixos.org/wiki/Overview_of_the_NixOS_Linux_distribution)

--- a/docs/nixos-with-flakes/introduction-to-flakes.md
+++ b/docs/nixos-with-flakes/introduction-to-flakes.md
@@ -118,7 +118,7 @@ is currently no alternative for this command):
    1. You can refer to the detailed command comparison list in
       [Try to explain nix commands](https://qiita.com/Sumi-Sumi/items/6de9ee7aab10bc0dbead?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en).
 
-[^1]: [Flakes - NixOS Wiki](https://nixos.wiki/index.php?title=Flakes)
+[^1]: [Flakes - NixOS Wiki](https://wiki.nixos.org/wiki/Flakes)
 [^2]:
     [Flakes are such an obviously good thing](https://grahamc.com/blog/flakes-are-an-obviously-good-thing/)
 

--- a/docs/nixos-with-flakes/modularize-the-configuration.md
+++ b/docs/nixos-with-flakes/modularize-the-configuration.md
@@ -17,7 +17,7 @@ The functions of these four files are:
 - `flake.lock`: An automatically generated version-lock file that records all input
   sources, hash values, and version numbers of the entire flake to ensure reproducibility.
 - `flake.nix`: The entry file that will be recognized and deployed when executing
-  `sudo nixos-rebuild switch`. See [Flakes - NixOS Wiki](https://nixos.wiki/wiki/Flakes)
+  `sudo nixos-rebuild switch`. See [Flakes - NixOS Wiki](https://wiki.nixos.org/wiki/Flakes)
   for all options of flake.nix.
 - `configuration.nix`: Imported as a Nix module in flake.nix, all system-level
   configuration is currently written here. See

--- a/docs/nixpkgs/multiple-nixpkgs.md
+++ b/docs/nixpkgs/multiple-nixpkgs.md
@@ -58,7 +58,7 @@ syntax is as follows:
     crossSystem = {
       config = "riscv64-unknown-linux-gnu";
 
-      # https://nixos.wiki/wiki/Build_flags
+      # https://wiki.nixos.org/wiki/Build_flags
       # this option equals to adding `-march=rv64gc` to CFLAGS.
       # CFLAGS will be used as the command line arguments for gcc/clang.
       gcc.arch = "rv64gc";

--- a/docs/other-usage-of-flakes/module-system.md
+++ b/docs/other-usage-of-flakes/module-system.md
@@ -441,8 +441,8 @@ section
 ## References
 
 - [Best resources for learning about the NixOS module system? - Discourse](https://discourse.nixos.org/t/best-resources-for-learning-about-the-nixos-module-system/1177/4)
-- [NixOS modules - NixOS Wiki](https://nixos.wiki/wiki/NixOS_modules)
-- [NixOS: config argument - NixOS Wiki](https://nixos.wiki/wiki/NixOS:config_argument)
+- [NixOS modules - NixOS Wiki](https://wiki.nixos.org/wiki/NixOS_modules)
+- [NixOS: config argument - NixOS Wiki](https://wiki.nixos.org/wiki/NixOS:config_argument)
 - [Module System - Nixpkgs]
 - [Writing NixOS Modules - Nixpkgs]
 

--- a/docs/other-usage-of-flakes/testing.md
+++ b/docs/other-usage-of-flakes/testing.md
@@ -5,7 +5,7 @@ TODO
 ## References
 
 - [Integration testing with NixOS virtual machines - nix.dev](https://nix.dev/tutorials/nixos/integration-testing-using-virtual-machines.html)
-- [NixOS Testing library](https://nixos.wiki/wiki/NixOS_Testing_library)
+- [NixOS Testing library](https://wiki.nixos.org/wiki/NixOS_Testing_library)
 - [Testing within NixOS - NixOS Manual](https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests)
 - [Testers - Nixpkgs Manual](https://nixos.org/manual/nixpkgs/unstable/#chap-testers)
 - [Unveiling the Power of the NixOS Integration Test Driver (Part 1)](https://nixcademy.com/2023/10/24/nixos-integration-tests/)

--- a/docs/zh/development/distributed-building.md
+++ b/docs/zh/development/distributed-building.md
@@ -147,7 +147,7 @@ NixOS 官方的 cache.nixos.org 中提供了绝大多数 X86_64 架构的缓存�
 
 ## References
 
-- [Distributed build - NixOS Wiki](https://nixos.wiki/wiki/Distributed_build)
+- [Distributed build - NixOS Wiki](https://wiki.nixos.org/wiki/Distributed_build)
 - [Document available system features - nix#7380](https://github.com/NixOS/nix/issues/7380)
 - [Distributed builds seem to disable local builds nix#2589](https://github.com/NixOS/nix/issues/2589)
 - [Offloading NixOS builds to a faster machine](https://sgt.hootr.club/molten-matter/nix-distributed-builds/)

--- a/docs/zh/development/intro.md
+++ b/docs/zh/development/intro.md
@@ -473,8 +473,8 @@ TODO 未完待续
 
 - [pkgs.mkShell - nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell)
 - [A minimal nix-shell](https://fzakaria.com/2021/08/02/a-minimal-nix-shell.html)
-- [Wrapping packages - NixOS Cookbook](https://nixos.wiki/wiki/Nix_Cookbook#Wrapping_packages)
+- [Wrapping packages - NixOS Cookbook](https://wiki.nixos.org/wiki/Nix_Cookbook#Wrapping_packages)
 - [One too many shell, Clearing up with nix' shells nix shell and nix-shell - Yannik Sander](https://blog.ysndr.de/posts/guides/2021-12-01-nix-shells/)
-- [Shell Scripts - NixOS Wiki](https://nixos.wiki/wiki/Shell_Scripts)
+- [Shell Scripts - NixOS Wiki](https://wiki.nixos.org/wiki/Shell_Scripts)
 
 [New Nix Commands]: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix.html

--- a/docs/zh/development/kernel-development.md
+++ b/docs/zh/development/kernel-development.md
@@ -80,7 +80,7 @@
       };
     in
       # the code here is mainly copied from:
-      #   https://nixos.wiki/wiki/Linux_kernel#Embedded_Linux_Cross-compile_xconfig_and_menuconfig
+      #   https://wiki.nixos.org/wiki/Linux_kernel#Embedded_Linux_Cross-compile_xconfig_and_menuconfig
       (pkgs.buildFHSUserEnv {
         name = "kernel-build-env";
         targetPkgs = pkgs_: (with pkgs_;
@@ -115,5 +115,5 @@
 
 ## References
 
-- [Linux kernel - NixOS Wiki](https://nixos.wiki/wiki/Linux_kernel)
+- [Linux kernel - NixOS Wiki](https://wiki.nixos.org/wiki/Linux_kernel)
 - https://github.com/jordanisaacs/kernel-module-flake

--- a/docs/zh/development/packaging-101.md
+++ b/docs/zh/development/packaging-101.md
@@ -8,7 +8,7 @@ WIP 未完成，目前请移步如下参考文档学习 Nix 打包。
 - [How to Learn Nix, Part 28: The standard environment](https://ianthehenry.com/posts/how-to-learn-nix/the-standard-environment/)
 - [stdenv - Nixpkgs Manual](https://github.com/NixOS/nixpkgs/tree/nixos-unstable/doc/stdenv)
 - [languages-frameworks - Nixpkgs Manual](https://github.com/NixOS/nixpkgs/tree/nixos-unstable/doc/languages-frameworks)
-- [Wrapping packages - NixOS Cookbook](https://nixos.wiki/wiki/Nix_Cookbook#Wrapping_packages)
+- [Wrapping packages - NixOS Cookbook](https://wiki.nixos.org/wiki/Nix_Cookbook#Wrapping_packages)
 - Useful tools:
   - [nurl](https://github.com/nix-community/nurl): Generate Nix fetcher calls from
     repository URLs

--- a/docs/zh/nix-store/add-binary-cache-servers.md
+++ b/docs/zh/nix-store/add-binary-cache-servers.md
@@ -32,7 +32,7 @@ Nix 中通过如下几个 options 来配置缓存服务器：
       三方库，但又希望使用它的第三方缓存服务器加快构建速度，那就必须自己承担对应的安全风
       险，自行决策是否将该缓存服务器的公钥添加进 `trusted-public-keys`。为了完全解决这个信
       任问题，Nix 推出了实验特性
-      [ca-derivations](https://nixos.wiki/wiki/Ca-derivations)，它不依赖
+      [ca-derivations](https://wiki.nixos.org/wiki/Ca-derivations)，它不依赖
       `trusted-public-keys` 进行签名校验，有兴趣的可以自行了解。
 
 可通过如下几种方式来配置 `substituters` `trusted-public-keys` 两个参数：

--- a/docs/zh/nix-store/host-your-own-binary-cache-server.md
+++ b/docs/zh/nix-store/host-your-own-binary-cache-server.md
@@ -212,6 +212,6 @@ mc ilm rule add s3/nix-cache --expire-days "DAYS"
 ## 参考
 
 - [Blog post by Jeff on Nix binary caches](https://jcollie.github.io/nixos/2022/04/27/nixos-binary-cache-2022.html)
-- [Binary cache in the NixOS wiki](https://nixos.wiki/wiki/Binary_Cache)
+- [Binary cache in the NixOS wiki](https://wiki.nixos.org/wiki/Binary_Cache)
 - [Serving a Nox store via S3 in the NixOS manual](https://nixos.org/manual/nix/stable/package-management/s3-substituter.html)
 - [Serving a Nix store via HTTP in the NixOS manual](https://nixos.org/manual/nix/stable/package-management/binary-cache-substituter.html)

--- a/docs/zh/nixos-with-flakes/get-started-with-nixos.md
+++ b/docs/zh/nixos-with-flakes/get-started-with-nixos.md
@@ -92,4 +92,4 @@ Flakes**，它可以确保系统的可复现性，同时也可以很方便地管
 
 ## 参考
 
-- [Overview of the NixOS Linux distribution](https://nixos.wiki/wiki/Overview_of_the_NixOS_Linux_distribution)
+- [Overview of the NixOS Linux distribution](https://wiki.nixos.org/wiki/Overview_of_the_NixOS_Linux_distribution)

--- a/docs/zh/nixos-with-flakes/introduction-to-flakes.md
+++ b/docs/zh/nixos-with-flakes/introduction-to-flakes.md
@@ -98,7 +98,7 @@ NixOS & Flakes 新手指南，就有必要介绍下 Flakes 实验特性所依赖
    1. 详细的命令对比列表可以看看
       [Try to explain nix commands](https://qiita-com.translate.goog/Sumi-Sumi/items/6de9ee7aab10bc0dbead?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en)
 
-[^1]: [Flakes - NixOS Wiki](https://nixos.wiki/index.php?title=Flakes)
+[^1]: [Flakes - NixOS Wiki](https://wiki.nixos.org/wiki/Flakes)
 [^2]:
     [Flakes are such an obviously good thing](https://grahamc.com/blog/flakes-are-an-obviously-good-thing/)
 

--- a/docs/zh/nixpkgs/multiple-nixpkgs.md
+++ b/docs/zh/nixpkgs/multiple-nixpkgs.md
@@ -49,7 +49,7 @@
     crossSystem = {
       config = "riscv64-unknown-linux-gnu";
 
-      # https://nixos.wiki/wiki/Build_flags
+      # https://wiki.nixos.org/wiki/Build_flags
       # this option equals to add `-march=rv64gc` into CFLAGS.
       # CFLAGS will be used as the command line arguments for the gcc/clang.
       gcc.arch = "rv64gc";

--- a/docs/zh/other-usage-of-flakes/module-system.md
+++ b/docs/zh/other-usage-of-flakes/module-system.md
@@ -400,8 +400,8 @@ options 的声明与类型检查。
 ## References
 
 - [Best resources for learning about the NixOS module system? - Discourse](https://discourse.nixos.org/t/best-resources-for-learning-about-the-nixos-module-system/1177/4)
-- [NixOS modules - NixOS Wiki](https://nixos.wiki/wiki/NixOS_modules)
-- [NixOS: config argument - NixOS Wiki](https://nixos.wiki/wiki/NixOS:config_argument)
+- [NixOS modules - NixOS Wiki](https://wiki.nixos.org/wiki/NixOS_modules)
+- [NixOS: config argument - NixOS Wiki](https://wiki.nixos.org/wiki/NixOS:config_argument)
 - [Module System - Nixpkgs][Module System - Nixpkgs]
 - [Writing NixOS Modules - Nixpkgs][Writing NixOS Modules - Nixpkgs]
 

--- a/docs/zh/other-usage-of-flakes/testing.md
+++ b/docs/zh/other-usage-of-flakes/testing.md
@@ -5,7 +5,7 @@ TODO
 ## References
 
 - [Integration testing with NixOS virtual machines - nix.dev](https://nix.dev/tutorials/nixos/integration-testing-using-virtual-machines.html)
-- [NixOS Testing library](https://nixos.wiki/wiki/NixOS_Testing_library)
+- [NixOS Testing library](https://wiki.nixos.org/wiki/NixOS_Testing_library)
 - [Testing within NixOS - NixOS Manual](https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests)
 - [Testers - Nixpkgs Manual](https://nixos.org/manual/nixpkgs/unstable/#chap-testers)
 - [Unveiling the Power of the NixOS Integration Test Driver (Part 1)](https://nixcademy.com/2023/10/24/nixos-integration-tests/)


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org
ref: NixOS/foundation#113