### PR TITLE
Fixed an error with the next and prev navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -235,7 +235,7 @@ function themeConfigEnglish() {
             { text: "Introduction", link: "/nix-store/intro.md" },
             {
               text: "Add Binary Cache Servers",
-              link: "nix-store/add-binary-cache-servers.md",
+              link: "/nix-store/add-binary-cache-servers.md",
             },
             {
               text: "Host Your Own Binary Cache Server",


### PR DESCRIPTION
The configuration on the sidebar for the section _Nix Store & Binary Cache_ on page _Add Binary Cache Servers_ missed a '/' in the link, to reference the root of the document.
That error resulted only in the button **Next page** that referenced the _Preface_ page.