### PR TITLE
Fix typo in remote-deployment.md: .#nixos-text -> .#my-nixos

### DIFF
--- a/docs/best-practices/remote-deployment.md
+++ b/docs/best-practices/remote-deployment.md
@@ -147,7 +147,7 @@ For instance, to deploy the configuration defined in the `nixosConfigurations.my
 your flake to a remote host, use the following command:
 
 ```bash
-nixos-rebuild switch --flake .#nixos-text \
+nixos-rebuild switch --flake .#my-nixos \
   --target-host root@192.168.4.1 --build-host localhost --verbose
 ```
 


### PR DESCRIPTION
Hi, thanks for the tutorial. Was confused by this. If I'm not missing something, this is a typo.