### PR TITLE
docs: fix logic typo

### DIFF
--- a/docs/en/nixos-with-flakes/other-useful-tips.md
+++ b/docs/en/nixos-with-flakes/other-useful-tips.md
@@ -32,7 +32,7 @@ For example, you can place your flake in `~/nixos-config` and create a symbolic 
 
 ```shell
 sudo mv /etc/nixos /etc/nixos.bak  # Backup the original configuration
-sudo ln -s ~/nixos-config/ /etc/nixos
+sudo ln -s ~/nixos-config /etc/nixos
 
 # Deploy the flake.nix located at the default location (/etc/nixos)
 sudo nixos-rebuild switch


### PR DESCRIPTION
trailing slash caused to copy directory. so the output was 
```shell
/etc/nixos/nixos-config/*.nix
```
and should be
```shell
/etc/nixos/*.nix
```