### PR TITLE
Update nixos-with-flakes-enabled.md

### DIFF
--- a/docs/en/nixos-with-flakes/nixos-with-flakes-enabled.md
+++ b/docs/en/nixos-with-flakes/nixos-with-flakes-enabled.md
@@ -33,7 +33,6 @@ the accompanying new nix command-line tool:
     git
     vim
     wget
-    curl
   ];
   # Set the default editor to vim
   environment.variables.EDITOR = "vim";


### PR DESCRIPTION
As far as I can tell, curl is installed by default on NixOS. Thus, having it here should be considered a bug (as it is both superfluous and implies that curl is not already installed on the system, which is confusing).