### PR TITLE
Update intro.md to echo the right nodejs version

### DIFF
--- a/docs/en/development/intro.md
+++ b/docs/en/development/intro.md
@@ -136,7 +136,7 @@ Here is a `flake.nix` that defines a development environment with Node.js 18 ins
       ];
 
       shellHook = ''
-        echo "node `${pkgs.nodejs_18}/bin/node --version`"
+        echo "node `node --version`"
       '';
     };
   };
@@ -181,7 +181,7 @@ Here is an example:
       ];
 
       shellHook = ''
-        echo "node `${pkgs.nodejs_18}/bin/node --version`"
+        echo "node `node --version`"
         exec nu
       '';
     };

--- a/docs/en/development/intro.md
+++ b/docs/en/development/intro.md
@@ -136,7 +136,7 @@ Here is a `flake.nix` that defines a development environment with Node.js 18 ins
       ];
 
       shellHook = ''
-        echo "node `${pkgs.nodejs}/bin/node --version`"
+        echo "node `${pkgs.nodejs_18}/bin/node --version`"
       '';
     };
   };
@@ -181,7 +181,7 @@ Here is an example:
       ];
 
       shellHook = ''
-        echo "node `${pkgs.nodejs}/bin/node --version`"
+        echo "node `${pkgs.nodejs_18}/bin/node --version`"
         exec nu
       '';
     };


### PR DESCRIPTION
The changes tweak the example flakes so they will output the correct `nodejs` version

In my case, `pkgs.nodejs` points to `node v20.19.0` and that's what the `shellHook` outputs. Thought, in a dev shell, `nodejs` is set to version 18

The fix is somewhat awkward, I guess there's a more lean way to use the same package version in both places, but I'm not sure the example merits it