### PR TITLE
Update flake registry related pages

### DIFF
--- a/docs/en/best-practices/nix-path-and-flake-registry.md
+++ b/docs/en/best-practices/nix-path-and-flake-registry.md
@@ -38,25 +38,23 @@ then downloads the repository, locates the `flake.nix` within, and runs the corr
 
 The roles of `NIX_PATH` and the Flake Registry have been explained earlier. In daily use,
 we typically want the `nixpkgs` used in commands like `nix repl '<nixpkgs>'`,
-`nix run nixpkgs#ponysay hello` to match the system's `nixpkgs`. This requires us to
-customize the `NIX_PATH` and Flake Registry. On the other hand, although `nix-channel` can
-coexist with the Flakes feature, in practice, Flakes can completely replace it, so we can
-also disable it.
+`nix run nixpkgs#ponysay hello` to match the system's `nixpkgs`. This is done
+by default as of [NixOS 24.05][automatic flake registry]. Also, although
+`nix-channel` can coexist with the Flakes feature, in practice, Flakes can
+completely replace it, so we can also disable it.
+
+[automatic flake registry]: https://github.com/NixOS/nixpkgs/pull/254405
 
 In your NixOS configuration, adding the following module will achieve the mentioned
 requirements:
 
 ```nix
-{lib, nixpkgs, ...}: {
-  # make `nix run nixpkgs#nixpkgs` use the same nixpkgs as the one used by this flake.
-  nix.registry.nixpkgs.flake = nixpkgs;
+{ nixpkgs, ... }: {
   nix.channel.enable = false; # remove nix-channel related tools & configs, we use flakes instead.
 
-  # but NIX_PATH is still used by many useful tools, so we set it to the same value as the one used by this flake.
-  # Make `nix repl '<nixpkgs>'` use the same nixpkgs as the one used by this flake.
-  environment.etc."nix/inputs/nixpkgs".source = "${nixpkgs}";
-  # https://github.com/NixOS/nix/issues/9574
-  nix.settings.nix-path = lib.mkForce "nixpkgs=/etc/nix/inputs/nixpkgs";
+  # this is set automatically by nixpkgs.lib.nixosSystem but might be required
+  # if one is not using that:
+  # nixpkgs.flake.source = nixpkgs;
 }
 ```
 

--- a/docs/en/nixos-with-flakes/introduction-to-flakes.md
+++ b/docs/en/nixos-with-flakes/introduction-to-flakes.md
@@ -87,18 +87,28 @@ the New CLI and Flakes (`nix-command` and `flakes`). When researching, you can r
 them with the corresponding New CLI commands (except for `nix-collect-garbage`, as there
 is currently no alternative for this command):
 
-1. `nix-channel`: `nix-channel` manages software package versions through
-   stable/unstable/test channels, similar to other package management tools such as
-   apt/yum/pacman.
-   1. In Flakes, The functionality of `nix-channel` is entirely replaced by the `inputs`
-      section in `flake.nix`.
+1. `nix-channel`: `nix-channel` manages versions of inputs like nixpkgs through
+   stable/unstable channels, similar to the package lists used by other package
+   management tools such as apt/yum/pacman. This is what traditionally provides
+   `<nixpkgs>` in the Nix language.
+   1. In Flakes, the functionality of `nix-channel` is replaced by
+      the Flake Registry (`nix registry`) for providing "some unspecified global
+      version of nixpkgs" for interactive CLI usage (e.g. `nix run nixpkgs#hello`).
+      When using a `flake.nix`, input versions are managed in the flake itself.
+   2. Flakes use the `inputs` section in `flake.nix` to manage
+      versions of nixpkgs and other inputs in each Flake instead of using
+      global state.
 2. `nix-env`: `nix-env` is a core command-line tool for classic Nix used to manage
    software packages in the user environment.
    1. It installs packages from the data sources added by `nix-channel`, causing the
       installed package's version to be influenced by the channel. Packages installed with
       `nix-env` are not automatically recorded in Nix's declarative configuration and are
       completely independent of its control, making them challenging to reproduce on other
-      machines. Therefore, it is not recommended to use this command directly.
+      machines. Upgrading packages installed by `nix-env` is slow and may
+      produce unexpected results because the attribute name where the package
+      was found in nixpkgs is not saved.
+
+      Therefore, it is not recommended to use this command directly.
    2. The corresponding command in the New CLI is `nix profile`. Personally, I don't
       recommend it for beginners.
 3. `nix-shell`: `nix-shell` creates a temporary shell environment, which is useful for


### PR DESCRIPTION
- NixOS automatically manages the flake registry because I fixed it.
- Clarify that nix-channel does have a spiritual successor in flakes in the form of the registry, but that it's kind of useless.