### PR TITLE
Fix link in other-usage-of-flakes/inputs

### DIFF
--- a/docs/en/other-usage-of-flakes/inputs.md
+++ b/docs/en/other-usage-of-flakes/inputs.md
@@ -3,7 +3,7 @@
 The `inputs` section in `flake.nix` is an attribute set used to specify the dependencies
 of the current flake. There are various types of inputs, as shown in the examples below:
 
-> See Offical docs for details - [Flakes Inputs - Nix Manual].
+> See Official docs for details - [Flakes Inputs - Nix Manual].
 
 ```nix
 {
@@ -71,4 +71,5 @@ of the current flake. There are various types of inputs, as shown in the example
 
 - [Flakes Inputs - Nix Manual]
 
-[Flakes Inputs - Nix Manual]: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references
+[Flakes Inputs - Nix Manual]:
+  https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-inputs


### PR DESCRIPTION
The link to "Flakes Inputs - Nix Manual" in [this page](https://nixos-and-flakes.thiscute.world/other-usage-of-flakes/inputs) would actually point to [the section explaining Flake References](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references). I changed the link to point to the [expected section](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-inputs).

The correction of the typo "Offical" to "Official" was done automatically by the `typos -w` command as instructed in the [contributing guidelines](https://github.com/ryan4yin/nixos-and-flakes-book/blob/bedbe5298feecd9a4d475da3b6edec505ab358aa/.github/CONTRIBUTING.md).