### PR TITLE
fix:update 'buildFHSUserEnv' to 'buildFHSUserEnv'

### DIFF
--- a/docs/en/best-practices/run-downloaded-binaries-on-nixos.md
+++ b/docs/en/best-practices/run-downloaded-binaries-on-nixos.md
@@ -25,10 +25,10 @@ add the following code to one of your Nix modules:
 
     # Create an FHS environment using the command `fhs`, enabling the execution of non-NixOS packages in NixOS!
     (let base = pkgs.appimageTools.defaultFhsEnvArgs; in
-      pkgs.buildFHSUserEnv (base // {
+      pkgs.buildFHSEnv (base // {
       name = "fhs";
       targetPkgs = pkgs:
-        # pkgs.buildFHSUserEnv provides only a minimal FHS environment,
+        # pkgs.buildFHSEnv provides only a minimal FHS environment,
         # lacking many basic packages needed by most software.
         # Therefore, we need to add them manually.
         #

--- a/docs/zh/best-practices/run-downloaded-binaries-on-nixos.md
+++ b/docs/zh/best-practices/run-downloaded-binaries-on-nixos.md
@@ -18,10 +18,10 @@ NixOS 不遵循 FHS 标准，因此你从网上下载的二进制程序在 NixOS
 
     # create a fhs environment by command `fhs`, so we can run non-nixos packages in nixos!
     (let base = pkgs.appimageTools.defaultFhsEnvArgs; in
-      pkgs.buildFHSUserEnv (base // {
+      pkgs.buildFHSEnv (base // {
       name = "fhs";
       targetPkgs = pkgs:
-        # pkgs.buildFHSUserEnv 只提供一个最小的 FHS 环境，缺少很多常用软件所必须的基础包
+        # pkgs.buildFHSEnv 只提供一个最小的 FHS 环境，缺少很多常用软件所必须的基础包
         # 所以直接使用它很可能会报错
         #
         # pkgs.appimageTools 提供了大多数程序常用的基础包，所以我们可以直接用它来补充


### PR DESCRIPTION
'buildFHSUserEnv' has been renamed to 'buildFHSEnv' and was removed in 25.11