### PR TITLE
feat: add Spanish community-maintained translation to README / picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://nixos-and-flakes.thiscute.world/
 
 - **Versão em Português**: https://nixos-and-flakes.ieda.me/
 - **日本語版**: https://nixos-and-flakes-ja.hayao0819.com/
+- **Versión en Español**: https://nixos-and-flakes.voros.xyz/
 
 > If you're using macOS,
 > [ryan4yin/nix-darwin-kickstarter](https://github.com/ryan4yin/nix-darwin-kickstarter)

--- a/docs/.vitepress/config/index.ts
+++ b/docs/.vitepress/config/index.ts
@@ -27,6 +27,10 @@ export default defineConfig({
       label: "日本語",
       link: "https://nixos-and-flakes-ja.hayao0819.com/",
     },
+    es: {
+      label: "Español",
+      link: "https://nixos-and-flakes.voros.xyz/",
+    },
   },
 
   // For forks in other languages, here is an example of how to add a new locale:


### PR DESCRIPTION
Adds the Spanish community-maintained translation link to the README and VitePress language picker.

Spanish version: https://nixos-and-flakes.voros.xyz/